### PR TITLE
Add simple static website preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 Hey there! 👋 I'm Ayoyinka, a passionate web developer and data analyst with a love for all things Python and React. Welcome to my GitHub profile, where I explore the world of coding and turn data into insights.
 
+
+## Quick Website Preview
+
+This repository now includes a simple static website preview in `index.html` styled with `styles.css`. Open `index.html` in a browser to view it locally.
+
 ## About Me
 
 - 😄 Pronouns: He/Him

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Burinious | Portfolio Snapshot</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Ayoyinka (Burinious)</h1>
+      <p class="intro">Web Developer • Data Analyst</p>
+
+      <section>
+        <h2>What I do</h2>
+        <ul>
+          <li>Build interactive web experiences with React.</li>
+          <li>Analyze datasets and turn results into practical insight.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Featured projects</h2>
+        <ul>
+          <li><a href="https://github.com/burinious/Student-Exam-Performance-Tracker">Student Exam Performance Tracker</a></li>
+          <li><a href="https://github.com/burinious/zodiac">Zodiac Sign and Compatibility App</a></li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Connect</h2>
+        <p>
+          <a href="https://www.linkedin.com/in/burinious">LinkedIn</a>
+          ·
+          <a href="https://twitter.com/burinious">Twitter</a>
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,55 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --text: #1d2735;
+  --card: #ffffff;
+  --accent: #1f6feb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: radial-gradient(circle at top, #ffffff, var(--bg));
+  color: var(--text);
+}
+
+.container {
+  max-width: 760px;
+  margin: 4rem auto;
+  background: var(--card);
+  border: 1px solid #e7ebf3;
+  border-radius: 14px;
+  padding: 2rem;
+  box-shadow: 0 10px 24px rgba(11, 24, 45, 0.08);
+}
+
+h1,
+h2 {
+  margin: 0 0 0.8rem;
+}
+
+.intro {
+  margin-top: 0;
+  color: #4e5d79;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+ul {
+  padding-left: 1.2rem;
+}
+
+section + section {
+  margin-top: 1.6rem;
+}


### PR DESCRIPTION
### Motivation
- Provide a quick, local preview of the portfolio in this repository so visitors can see a clean snapshot without needing to run the full project.

### Description
- Added a lightweight static page `index.html` that presents a short portfolio snapshot with sections for skills, featured projects, and social links.
- Added `styles.css` to give the page a clean, card-style layout, typography, spacing, and link styling.
- Updated `README.md` to include a `## Quick Website Preview` note that explains how to open the local preview.

### Testing
- Started a local HTTP server with `python -m http.server 4173 --directory /workspace/burinious` and confirmed the site served successfully (HTTP 200 responses for `index.html` and `styles.css`).
- Captured a visual verification screenshot using a Playwright script that ran `page.goto('http://127.0.0.1:4173/index.html', wait_until='domcontentloaded')` and `page.screenshot(path='artifacts/website-preview.png', full_page=True')`, which completed successfully and produced `artifacts/website-preview.png`.
- Verified repository state after changes with `git status --short` to ensure only the intended files were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a018f3547c833191e25cf9b3836ce8)